### PR TITLE
fix: 路径绑定错误

### DIFF
--- a/template/breadcrumb/index.vue
+++ b/template/breadcrumb/index.vue
@@ -3,7 +3,7 @@
     <el-breadcrumb separator="/">
       <el-breadcrumb-item
         v-for="(item, index) in breadcrumbData"
-        :to="item.clickable ? item.path : ''"
+        :to="item.clickable ? replacePath(item.path) : ''"
         :key="index">
         {{ item.name }}
       </el-breadcrumb-item>
@@ -28,6 +28,18 @@ export default {
 
     curBreadcrumb () {
       return this.breadcrumbData[this.breadcrumbData.length - 1]
+    }
+  },
+
+  methods: {
+    replacePath (path) {
+      return path
+        .split('/')
+        .map(item =>
+          item.startsWith('_')
+           ? this.$route.params[item.substring(1)]
+              : item)
+        .join('/')
     }
   }
 }


### PR DESCRIPTION
## WHY
由于没有把动态路径替换成真实的路径，导致点击跳转时，会跳到不存在的页面

## HOW
面包屑绑定路径时，把动态路径（“_” 开头的路径）替换成真实路径

## TEST
- before 
![before](https://user-images.githubusercontent.com/26338853/63606874-a95a9c00-c603-11e9-91be-6b7f2b7c1580.gif)

- after
![after](https://user-images.githubusercontent.com/26338853/63606890-b37c9a80-c603-11e9-999b-5a84b8b2ad09.gif)

