### PR TITLE
fix: 生成的 vue 文件 name 属性不规范

### DIFF
--- a/lib/bcg.js
+++ b/lib/bcg.js
@@ -49,7 +49,7 @@ function generateVueFile(newPagePath) {
       return
     }
 
-    const fileName = path.basename(newPagePath).replace(VUE_SUFFIX, '')
+    const fileName = path.basename(newPagePath).replace(/^_?(.+?)(?:\.vue)$/, (match, $1) => $1)
     const vuePage = fs.readFileSync(source.VUE_PAGE_PATH, 'utf8')
     const template = Handlebars.compile(vuePage)
     const result = template({ filename: fileName })


### PR DESCRIPTION
## WHY
在vue页面模版中使用了文件名作为 name 属性，当生成动态路由页面时，由于文件名是下划线开头，而 vue 中 name 下划线开头将会报错 

## HOW
使用 replace 取文件名 下划线 与 ".vue" 之间部分

## TEST
bcg new app
bcg new _app
bcg new app-app
bcg new _app-app
bcg new _app-app_app

bcg new app.vue.vue
bcg new _app.vue.vue
bcg new app-app.vue.vue
bcg new _app-app.vue.vue
bcg new _app-app_app.vue.vue