### PR TITLE
feat: 修改面包屑展示逻辑

### DIFF
--- a/template/breadcrumb/index.vue
+++ b/template/breadcrumb/index.vue
@@ -12,18 +12,20 @@
 </template>
 
 <script>
-import breadcrumbs from "./breadcrumb.config"
+import {mapState} from 'vuex'
 
 export default {
   name: 'Breadcrumb',
 
   computed: {
-    isBreadcrumbShow () {
-      return this.breadcrumbData && this.breadcrumbData.length && this.curBreadcrumb.isShow
+    ...mapState('breadcrumb',['breadcrumbData']),
+    
+    breadcrumbs () {
+      return Array.isArray(this.breadcrumbData) ? this.breadcrumbData.filter(crumb=>crumb.isShow) : []
     },
 
-    breadcrumbData () {
-      return this.$store.state.breadcrumb.breadcrumbData
+    isBreadcrumbShow () {
+      return this.breadcrumbs && this.breadcrumbs.length
     },
 
     curBreadcrumb () {


### PR DESCRIPTION
## 目的

有些页面只需显示该页面的父级面包屑，不需要显示该页面对应的面包屑

## 修改方案

过滤掉isShow为false的面包屑数据即可
```javascript
breadcrumbs () {
      return Array.isArray(this.breadcrumbData) ? this.breadcrumbData.filter(crumb=>crumb.isShow) : []
 },
```
