### PR TITLE
fix: 是否显示当前层级面包屑

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ bcg new app/detail -b src/views
   [{
     "clickable": false, // 是否可点击跳转
     "isShow": true, // 该路径下是否显示面包屑
+    "isCurrentShow": true, // 该路径下是否当前层级面包屑
     "name": "应用", // 显示的面包屑名称
     "path": "/app" // 路径
   }]
@@ -92,13 +93,13 @@ bcg new app/detail -b src/views
 
 第四步：生成一个页面
 
-![new-command](http://tva1.sinaimg.cn/large/0060lm7Tly1g654fvu5w5j30ht0c575f.jpg)
+![new-command](http://tva1.sinaimg.cn/large/007X8olVly1g6hyfutt7gj30lh0bddgh.jpg)
 
 可以看到页面与配置已经生成了
 
 ![page](http://tva1.sinaimg.cn/large/0060lm7Tly1g654gryzazj308f0350sj.jpg)
 
-![comfiguration](http://tva1.sinaimg.cn/large/0060lm7Tly1g654hhnd4uj30ea0hcaay.jpg)
+![comfiguration](http://tva1.sinaimg.cn/large/007X8olVly1g6hy38uo2fj30kl0j4wf2.jpg)
 
 第五步：启动项目，打开 /app/detail/my-app 查看效果
 
@@ -116,7 +117,7 @@ bcg new app/detail -b src/views
 
 假设有一个参数为 type 的动态路由，我们生成这个页面，并且设置面包屑名称为 "动态_类型"
 
-![new-_type](http://tva1.sinaimg.cn/large/007X8olVly1g6b4fg7v6fj30ge0ay3zb.jpg)
+![new-_type](http://tva1.sinaimg.cn/large/007X8olVly1g6hyhy8phdj30i90a4dg7.jpg)
 
 在刚刚生成的 _type.vue 中动态设置这个名称
 
@@ -133,7 +134,7 @@ bcg new app/detail -b src/views
 
 这么做的话有一点需要注意：**就是要将原数据复制一份进行修改，否则就变成直接修改 state 了，将会报 vuex 相关错误**
 
-![set-breadcrumb-data](http://tva1.sinaimg.cn/large/0060lm7Tly1g658ppwul8j30r10f0ta7.jpg)
+![set-breadcrumb-data](http://tva1.sinaimg.cn/large/007X8olVly1g6hya8zvjcj30sj0eamxr.jpg)
 
 查看效果
 

--- a/lib/bcg.js
+++ b/lib/bcg.js
@@ -67,7 +67,7 @@ function generateVueFile(newPagePath) {
 function updateConfiguration(filePath, {
   clickable,
   isShow,
-  isCurShow
+  isCurrentShow
 } = {}) {
   try {
     if (!fs.existsSync(target.BREADCRUMB_JSON_PATH)) {
@@ -97,7 +97,7 @@ function updateConfiguration(filePath, {
         configurationArr.push({
           clickable: index === pathArrLastIdx ? clickable : false,
           isShow: index === pathArrLastIdx ? isShow : true,
-          isCurShow: index === pathArrLastIdx ? isCurShow : true,
+          isCurrentShow: index === pathArrLastIdx ? isCurrentShow : true,
           name: answers[pathItem],
           path: pathItem
         })
@@ -131,7 +131,7 @@ function generating(newPagePath, filePath) {
     },
     {
       type: 'confirm',
-      name: 'isCurShow',
+      name: 'isCurrentShow',
       message: '是否展示当前层级面包屑? (默认 yes)',
       default: true
     },
@@ -141,14 +141,14 @@ function generating(newPagePath, filePath) {
       message: '是否仅生成配置而不生成文件? (默认 no)',
       default: false
     }
-  ]).then(({ clickable, isShow, isCurShow, onlyConfig }) => {
+  ]).then(({ clickable, isShow, isCurrentShow, onlyConfig }) => {
     if (onlyConfig) {
-      updateConfiguration(filePath, { clickable, isShow, isCurShow })
+      updateConfiguration(filePath, { clickable, isShow, isCurrentShow })
       return
     }
 
     generateVueFile(newPagePath)
-    updateConfiguration(filePath, { clickable, isShow, isCurShow })
+    updateConfiguration(filePath, { clickable, isShow, isCurrentShow })
   })
 }
 

--- a/lib/bcg.js
+++ b/lib/bcg.js
@@ -66,7 +66,8 @@ function generateVueFile(newPagePath) {
 
 function updateConfiguration(filePath, {
   clickable,
-  isShow
+  isShow,
+  isCurShow
 } = {}) {
   try {
     if (!fs.existsSync(target.BREADCRUMB_JSON_PATH)) {
@@ -96,6 +97,7 @@ function updateConfiguration(filePath, {
         configurationArr.push({
           clickable: index === pathArrLastIdx ? clickable : false,
           isShow: index === pathArrLastIdx ? isShow : true,
+          isCurShow: index === pathArrLastIdx ? isCurShow : true,
           name: answers[pathItem],
           path: pathItem
         })
@@ -129,18 +131,24 @@ function generating(newPagePath, filePath) {
     },
     {
       type: 'confirm',
+      name: 'isCurShow',
+      message: '是否展示当前层级面包屑? (默认 yes)',
+      default: true
+    },
+    {
+      type: 'confirm',
       name: 'onlyConfig',
       message: '是否仅生成配置而不生成文件? (默认 no)',
       default: false
     }
-  ]).then(({ clickable, isShow, onlyConfig }) => {
+  ]).then(({ clickable, isShow, isCurShow, onlyConfig }) => {
     if (onlyConfig) {
-      updateConfiguration(filePath, { clickable, isShow })
+      updateConfiguration(filePath, { clickable, isShow, isCurShow })
       return
     }
 
     generateVueFile(newPagePath)
-    updateConfiguration(filePath, { clickable, isShow })
+    updateConfiguration(filePath, { clickable, isShow, isCurShow })
   })
 }
 

--- a/template/breadcrumb/index.vue
+++ b/template/breadcrumb/index.vue
@@ -19,7 +19,7 @@ export default {
 
   computed: {
     filterBreadcrumbData() {
-      return this.breadcrumbData.filter(item => item.isCurShow)
+      return this.breadcrumbData.filter(item => item.isCurrentShow)
     },
 
     isBreadcrumbShow () {

--- a/template/breadcrumb/index.vue
+++ b/template/breadcrumb/index.vue
@@ -2,8 +2,7 @@
   <div class="bcg-breadcrumb" v-if="isBreadcrumbShow">
     <el-breadcrumb separator="/">
       <el-breadcrumb-item
-        v-for="(item, index) in breadcrumbData"
-        v-if="item.isCurShow"
+        v-for="(item, index) in filterBreadcrumbData"
         :to="item.clickable ? replacePath(item.path) : ''"
         :key="index">
         {{ item.name }}
@@ -19,6 +18,10 @@ export default {
   name: 'Breadcrumb',
 
   computed: {
+    filterBreadcrumbData() {
+      return this.breadcrumbData.filter(item => item.isCurShow)
+    },
+
     isBreadcrumbShow () {
       return this.breadcrumbData && this.breadcrumbData.length && this.curBreadcrumb.isShow
     },

--- a/template/breadcrumb/index.vue
+++ b/template/breadcrumb/index.vue
@@ -3,6 +3,7 @@
     <el-breadcrumb separator="/">
       <el-breadcrumb-item
         v-for="(item, index) in breadcrumbData"
+        v-if="item.isCurShow"
         :to="item.clickable ? replacePath(item.path) : ''"
         :key="index">
         {{ item.name }}

--- a/template/breadcrumb/index.vue
+++ b/template/breadcrumb/index.vue
@@ -2,7 +2,7 @@
   <div class="bcg-breadcrumb" v-if="isBreadcrumbShow">
     <el-breadcrumb separator="/">
       <el-breadcrumb-item
-        v-for="(item, index) in filterBreadcrumbData"
+        v-for="(item, index) in displayedBreadcrumbData"
         :to="item.clickable ? replacePath(item.path) : ''"
         :key="index">
         {{ item.name }}
@@ -18,7 +18,7 @@ export default {
   name: 'Breadcrumb',
 
   computed: {
-    filterBreadcrumbData() {
+    displayedBreadcrumbData() {
       return this.breadcrumbData.filter(item => item.isCurrentShow)
     },
 

--- a/test/breadcrumb.test.js
+++ b/test/breadcrumb.test.js
@@ -12,6 +12,7 @@ describe('测试 mutations', () => {
       {
         "clickable": false,
         "isShow": true,
+        "isCurShow": true,
         "name": "应用",
         "path": "/app"
       }
@@ -26,6 +27,7 @@ describe('测试 mutations', () => {
       breadcrumbData: [{
         "clickable": false,
         "isShow": true,
+        "isCurShow": true,
         "name": "动态_类型",
         "path": "/_type"
       }]
@@ -38,6 +40,7 @@ describe('测试 mutations', () => {
     expect(state.breadcrumbData).toEqual([{
       "clickable": false,
       "isShow": true,
+      "isCurShow": true,
       "name": "类型一",
       "path": "/_type"
     }])
@@ -48,6 +51,7 @@ describe('测试 mutations', () => {
       breadcrumbData: [{
         "clickable": false,
         "isShow": true,
+        "isCurShow": true,
         "name": "应用",
         "path": "/app"
       }]
@@ -60,6 +64,7 @@ describe('测试 mutations', () => {
     expect(state.breadcrumbData).toEqual([{
       "clickable": false,
       "isShow": true,
+      "isCurShow": true,
       "name": "应用",
       "path": "/app"
     }])
@@ -70,11 +75,13 @@ describe('测试 mutations', () => {
       breadcrumbData: [{
         "clickable": false,
         "isShow": true,
+        "isCurShow": true,
         "name": "动态_类型",
         "path": "/_type"
       }, {
         "clickable": false,
         "isShow": true,
+        "isCurShow": true,
         "name": "动态_类型",
         "path": "/_type/_type"
       }]
@@ -87,11 +94,13 @@ describe('测试 mutations', () => {
     expect(state.breadcrumbData).toEqual([{
       "clickable": false,
       "isShow": true,
+      "isCurShow": true,
       "name": "类型一",
       "path": "/_type"
     }, {
       "clickable": false,
       "isShow": true,
+      "isCurShow": true,
       "name": "动态_类型",
       "path": "/_type/_type"
     }])

--- a/test/breadcrumb.test.js
+++ b/test/breadcrumb.test.js
@@ -12,7 +12,7 @@ describe('测试 mutations', () => {
       {
         "clickable": false,
         "isShow": true,
-        "isCurShow": true,
+        "isCurrentShow": true,
         "name": "应用",
         "path": "/app"
       }
@@ -27,7 +27,7 @@ describe('测试 mutations', () => {
       breadcrumbData: [{
         "clickable": false,
         "isShow": true,
-        "isCurShow": true,
+        "isCurrentShow": true,
         "name": "动态_类型",
         "path": "/_type"
       }]
@@ -40,7 +40,7 @@ describe('测试 mutations', () => {
     expect(state.breadcrumbData).toEqual([{
       "clickable": false,
       "isShow": true,
-      "isCurShow": true,
+      "isCurrentShow": true,
       "name": "类型一",
       "path": "/_type"
     }])
@@ -51,7 +51,7 @@ describe('测试 mutations', () => {
       breadcrumbData: [{
         "clickable": false,
         "isShow": true,
-        "isCurShow": true,
+        "isCurrentShow": true,
         "name": "应用",
         "path": "/app"
       }]
@@ -64,7 +64,7 @@ describe('测试 mutations', () => {
     expect(state.breadcrumbData).toEqual([{
       "clickable": false,
       "isShow": true,
-      "isCurShow": true,
+      "isCurrentShow": true,
       "name": "应用",
       "path": "/app"
     }])
@@ -75,13 +75,13 @@ describe('测试 mutations', () => {
       breadcrumbData: [{
         "clickable": false,
         "isShow": true,
-        "isCurShow": true,
+        "isCurrentShow": true,
         "name": "动态_类型",
         "path": "/_type"
       }, {
         "clickable": false,
         "isShow": true,
-        "isCurShow": true,
+        "isCurrentShow": true,
         "name": "动态_类型",
         "path": "/_type/_type"
       }]
@@ -94,13 +94,13 @@ describe('测试 mutations', () => {
     expect(state.breadcrumbData).toEqual([{
       "clickable": false,
       "isShow": true,
-      "isCurShow": true,
+      "isCurrentShow": true,
       "name": "类型一",
       "path": "/_type"
     }, {
       "clickable": false,
       "isShow": true,
-      "isCurShow": true,
+      "isCurrentShow": true,
       "name": "动态_类型",
       "path": "/_type/_type"
     }])


### PR DESCRIPTION
## WHY
需要隐藏某个层级的面包屑

## HOW
增加多一个isCurrentShow的字段，来判断是否显示当前层级的面包屑

## TEST
1. 新增了一个”是否展示当前层级面包屑？“的提示？用于生成配置中的isCurrentShow属性
![image](https://user-images.githubusercontent.com/24385361/64012654-afdf9b00-cb50-11e9-998b-09fc6520eb70.png)

2. 在面包屑组件文件把breadcrumbData过滤掉属性isCurrentShow为false的对象，来控制显示各个层级的面包屑
![image](https://user-images.githubusercontent.com/24385361/64017158-7d876b00-cb5b-11e9-8cd9-c34a53b29a9b.png)



3. 查看效果
![image](https://user-images.githubusercontent.com/24385361/64017206-a3147480-cb5b-11e9-85b3-cc9d6df9f3ff.png)


![image](https://user-images.githubusercontent.com/24385361/64013050-91c66a80-cb51-11e9-8658-ee808925a11b.png)


