### PR TITLE
fix: query 没有加到 path 中

### DIFF
--- a/template/route.js
+++ b/template/route.js
@@ -1,10 +1,12 @@
+import qs from 'qs'
+import _cloneDeep from 'lodash/cloneDeep'
 import breadcrumbs from '@/components/breadcrumb/breadcrumb.config.json'
 
 function path2Arr(path) {
   return path.split('/').filter(p => p)
 }
 
-function matchBreadcrumbData (matchPath) {
+function matchBreadcrumbData(matchPath) {
   return path2Arr(matchPath)
     .map(path => {
       path = path.replace(/^:([^:?]+)(\?)?$/, (match, $1) => {
@@ -13,7 +15,6 @@ function matchBreadcrumbData (matchPath) {
       return '/' + path
     })
     .map((path, index, paths) => {
-
       // 第 0 个不需拼接
       if (index) {
         let result = ''
@@ -38,7 +39,7 @@ function matchBreadcrumbData (matchPath) {
     })
 }
 
-export default ({ app, store }) => {
+export default ({app, store, query}) => {
   app.router.beforeEach((to, from, next) => {
     const toPathArr = path2Arr(to.path)
     const toPathArrLength = toPathArr.length
@@ -53,7 +54,15 @@ export default ({ app, store }) => {
       }
     }
 
-    const breadcrumbData = matchBreadcrumbData(matchPath)
+    const breadcrumbData = _cloneDeep(matchBreadcrumbData(matchPath))
+
+    const query = to.query
+    if (Object.keys(query).length) {
+      const queryStr = qs.stringify(query)
+      const lastIndex = breadcrumbData.length - 1
+      const lastPath = breadcrumbData[lastIndex].path
+      breadcrumbData[lastIndex].path = `${lastPath}?${queryStr}`
+    }
 
     store.commit('breadcrumb/setBreadcrumb', breadcrumbData)
     next()

--- a/template/route.js
+++ b/template/route.js
@@ -1,5 +1,4 @@
 import qs from 'qs'
-import _cloneDeep from 'lodash/cloneDeep'
 import breadcrumbs from '@/components/breadcrumb/breadcrumb.config.json'
 
 function path2Arr(path) {
@@ -26,20 +25,22 @@ function matchBreadcrumbData(matchPath) {
       return path
     })
     .map(path => {
-      const item = breadcrumbs.find(bread => bread.path === path)
-      if (item) {
-        return item
-      }
-      return {
+      const item = breadcrumbs.find(bread => {
+        // path 有可能拼接了 query 需要去掉才能与 to.matched 分割出的 path 匹配上
+        bread.path = bread.path.replace(/\?\S+/, '')
+        return bread.path === path
+      })
+
+      return item || {
         name: path.split('/').pop(),
         path,
         clickable: false,
-        isShow: true
+        isShow: true,
       }
     })
 }
 
-export default ({app, store, query}) => {
+export default ({app, store}) => {
   app.router.beforeEach((to, from, next) => {
     const toPathArr = path2Arr(to.path)
     const toPathArrLength = toPathArr.length
@@ -54,7 +55,7 @@ export default ({app, store, query}) => {
       }
     }
 
-    const breadcrumbData = _cloneDeep(matchBreadcrumbData(matchPath))
+    const breadcrumbData = matchBreadcrumbData(matchPath)
 
     const query = to.query
     if (Object.keys(query).length) {

--- a/template/route.js
+++ b/template/route.js
@@ -35,7 +35,7 @@ function matchBreadcrumbData(matchPath) {
         name: path.split('/').pop(),
         path,
         clickable: false,
-        isShow: true,
+        isShow: true
       }
     })
 }


### PR DESCRIPTION
## WHY
面包屑数据的 path 是没有保存 query 的，如果跳转时带有 query，那么 url 与 面包屑数据的 path 会不相符，导致当前页面的面包屑可以点击，而点击后会跳到面包屑数据的 path，导致 query 丢失

## HOW
跳转页面前把 query 存到最后一级面包屑的 path 里
